### PR TITLE
Add defaultLayout:null to components to remove blank text node in Input

### DIFF
--- a/addon/components/labeled-radio-button.js
+++ b/addon/components/labeled-radio-button.js
@@ -6,7 +6,7 @@ export default Ember.Component.extend({
   tagName: 'label',
   classNameBindings: ['checked'],
   classNames: ['ember-radio-button'],
-  defaultLayout: null,
+  defaultLayout: null, // ie8 support
 
   checked: computed('groupValue', 'value', function(){
     return this.get('groupValue') === this.get('value');

--- a/addon/components/labeled-radio-button.js
+++ b/addon/components/labeled-radio-button.js
@@ -6,6 +6,7 @@ export default Ember.Component.extend({
   tagName: 'label',
   classNameBindings: ['checked'],
   classNames: ['ember-radio-button'],
+  defaultLayout: null,
 
   checked: computed('groupValue', 'value', function(){
     return this.get('groupValue') === this.get('value');

--- a/addon/components/radio-button-base.js
+++ b/addon/components/radio-button-base.js
@@ -13,7 +13,7 @@ export default Ember.Component.extend({
   tagName: 'input',
   type: 'radio',
   value: null,
-  defaultLayout: null,
+  defaultLayout: null, // ie8 support
 
   attributeBindings: boundAttributeKeys
 });

--- a/addon/components/radio-button-base.js
+++ b/addon/components/radio-button-base.js
@@ -13,6 +13,7 @@ export default Ember.Component.extend({
   tagName: 'input',
   type: 'radio',
   value: null,
+  defaultLayout: null,
 
   attributeBindings: boundAttributeKeys
 });


### PR DESCRIPTION
This fixes issue #9 by adding `defaultLayout: null` to the components. It stops ember from inserting a blank text node into the `input` tag. This causes errors in IE8.