### PR TITLE
Set the `for` attribute on the labeled-radio-button

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,14 @@ matrix:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
-  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
   - "npm config set spin false"
   - "npm install -g npm@^2"
 
 install:
+  - mkdir travis-phantomjs
+  - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
+  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C $PWD/travis-phantomjs
+  - export PATH=$PWD/travis-phantomjs:$PATH
   - npm install -g bower
   - npm install
   - bower install

--- a/addon/components/labeled-radio-button.js
+++ b/addon/components/labeled-radio-button.js
@@ -4,6 +4,7 @@ var computed = Ember.computed;
 
 export default Ember.Component.extend({
   tagName: 'label',
+  attributeBindings: ['for'],
   classNameBindings: ['checked'],
   classNames: ['ember-radio-button'],
   defaultLayout: null, // ie8 support
@@ -11,6 +12,8 @@ export default Ember.Component.extend({
   checked: computed('groupValue', 'value', function(){
     return this.get('groupValue') === this.get('value');
   }).readOnly(),
+
+  'for': computed.readOnly('radioId'),
 
   actions: {
     innerRadioChanged: function(value) {

--- a/addon/components/radio-button-input.js
+++ b/addon/components/radio-button-input.js
@@ -12,6 +12,8 @@ export default Ember.Component.extend({
   // disabled - optional
   // name - optional
   // required - optional
+  // radioClass - string
+  // radioId - string
 
   defaultLayout: null, // ie8 support
 

--- a/addon/components/radio-button.js
+++ b/addon/components/radio-button.js
@@ -11,6 +11,8 @@ export default Ember.Component.extend({
   // disabled - boolean
   // required - boolean
   // name - string
+  // radioClass - string
+  // radioId - string
 
   // polyfill hasBlock for ember versions < 1.13
   hasBlock: computed.bool('template').readOnly(),

--- a/app/templates/components/labeled-radio-button.hbs
+++ b/app/templates/components/labeled-radio-button.hbs
@@ -1,4 +1,6 @@
 {{radio-button
+    radioClass=radioClass
+    radioId=radioId
     changed="innerRadioChanged"
     disabled=disabled
     groupValue=groupValue

--- a/app/templates/components/radio-button.hbs
+++ b/app/templates/components/radio-button.hbs
@@ -1,6 +1,8 @@
 {{#if hasBlock}}
-  <label class="ember-radio-button {{if checked 'checked'}} {{joinedClassNames}}">
+  <label class="ember-radio-button {{if checked 'checked'}} {{joinedClassNames}}" for={{radioId}}>
     {{radio-button-input
+        class=radioClass
+        id=radioId
         disabled=disabled
         name=name
         required=required
@@ -12,6 +14,8 @@
   </label>
 {{else}}
   {{radio-button-input
+      class=radioClass
+      id=radioId
       disabled=disabled
       name=name
       required=required

--- a/tests/unit/components/labeled-radio-button-test.js
+++ b/tests/unit/components/labeled-radio-button-test.js
@@ -38,3 +38,29 @@ test('it gives the label of a wrapped checkbox a `checked` className', function(
 
   assert.equal(this.$('label').hasClass('checked'), true);
 });
+
+test('it gives the label of a wrapped radio button a `for` attribute', function(assert) {
+  assert.expect(4);
+
+  this.set('value', 'component-value');
+
+  this.render(hbs`
+    {{#labeled-radio-button
+      radioId='green-0'
+      radioClass='my-radio-class'
+      groupValue='initial-group-value'
+      value=value
+    }}
+      Green
+    {{/labeled-radio-button}}
+  `);
+
+  run(() => {
+    this.$('label').trigger('click');
+  });
+
+  assert.equal(this.$('label').attr('for'), 'green-0', 'the label has the correct `for` attribute');
+  assert.equal(this.$('input').attr('id'), 'green-0', 'the input has the correct `id` attribute');
+  assert.equal(this.$('input').hasClass('my-radio-class'), true, 'the input has the right class');
+  assert.equal(this.$('input:checked').length, 1, 'clicking the label checks the radio');
+});

--- a/tests/unit/components/radio-button-test.js
+++ b/tests/unit/components/radio-button-test.js
@@ -240,3 +240,29 @@ test('it binds attributes only to the input when used as a block', function(asse
   assert.equal($input.prop('required'), true);
   assert.equal($input.attr('value'), 'blue');
 });
+
+test('it checks the input when the label is clicked and has a `for` attribute', function(assert) {
+  assert.expect(4);
+
+  this.set('value', 'component-value');
+
+  this.render(hbs`
+    {{#radio-button
+      radioId='green-0'
+      radioClass='my-radio-class'
+      groupValue='initial-group-value'
+      value=value
+    }}
+      Green
+    {{/radio-button}}
+  `);
+
+  run(() => {
+    this.$('label').trigger('click');
+  });
+
+  assert.equal(this.$('label').attr('for'), 'green-0', 'the label has the correct `for` attribute');
+  assert.equal(this.$('input').attr('id'), 'green-0', 'the input has the correct `id` attribute');
+  assert.equal(this.$('input').hasClass('my-radio-class'), true, 'the input has the right class');
+  assert.equal(this.$('input:checked').length, 1, 'clicking the label checks the radio');
+});


### PR DESCRIPTION
This PR is to allow the checking of a radio input by clicking on the
label that has its input id as its `for` attribute.