### PR TITLE
[Not ready for merge] Data down actions up

### DIFF
--- a/addon/components/radio-button-input.js
+++ b/addon/components/radio-button-input.js
@@ -39,7 +39,6 @@ export default Ember.Component.extend({
     let groupValue = this.get('groupValue');
 
     if (groupValue !== value) {
-      this.set('groupValue', value); // violates DDAU
       Ember.run.once(this, 'sendChangedAction');
     }
   }

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -6,7 +6,19 @@ export default Ember.Controller.extend({
   noDefault: '',
   actions: {
     colorChanged(color) {
-      window.alert(`Color changed to ${color}`);
+      this.set('color', color);
+    },
+    numbersDisabledChanged(numbersDisabled) {
+      this.set('numbersDisabled', numbersDisabled);
+    },
+    numberChanged(number) {
+      this.set('number', number);
+    },
+    noDefaultChanged(noDefault) {
+      this.set('noDefault', noDefault);
+    },
+    modelNumberChanged(modelNumber) {
+      this.set('reservation.number', modelNumber);
     }
   },
   reservation: Ember.Object.create({

--- a/tests/dummy/app/templates/examples/basic.hbs
+++ b/tests/dummy/app/templates/examples/basic.hbs
@@ -1,19 +1,19 @@
 <p style="background-color: #F7F7F7;padding: 15px 20px;">
   <code>
-    \{{#radio-button value="green" groupValue=color changed="colorChanged"}}<br>
+    \{{#radio-button value="green" groupValue=color name="color" changed="colorChanged"}}<br>
       &nbsp;&nbsp;Green<br>
     \{{/radio-button}}<br>
-    \{{#radio-button value="blue" groupValue=color changed="colorChanged"}}<br>
+    \{{#radio-button value="blue" groupValue=color name="color" changed="colorChanged"}}<br>
       &nbsp;&nbsp;Blue<br>
     \{{/radio-button}}<br>
   </code>
 </p>
 <strong>Selected Color:</strong> {{color}}
 <p>
-  {{#radio-button value="green" groupValue=color changed="colorChanged"}}
+  {{#radio-button value="green" groupValue=color name="color" changed="colorChanged"}}
     Green
   {{/radio-button}}
-  {{#radio-button value="blue" groupValue=color changed="colorChanged"}}
+  {{#radio-button value="blue" groupValue=color name="color" changed="colorChanged"}}
     Blue
   {{/radio-button}}
 </p>

--- a/tests/dummy/app/templates/examples/disabled.hbs
+++ b/tests/dummy/app/templates/examples/disabled.hbs
@@ -1,20 +1,20 @@
 <h3>Disabled flag</h3>
 <p style="background-color: #F7F7F7;padding: 15px 20px;">
   <code>
-    \{{#radio-button value=true groupValue=numbersDisabled}}<br>
+    \{{#radio-button value=true groupValue=numbersDisabled name="number-disabled" changed="numbersDisabledChanged"}}<br>
       &nbsp;&nbsp;Disabled<br>
     \{{/radio-button}}<br>
-    \{{#radio-button value=false groupValue=numbersDisabled}}<br>
+    \{{#radio-button value=false groupValue=numbersDisabled name="number-disabled" changed="numbersDisabledChanged"}}<br>
       &nbsp;&nbsp;Enabled<br>
     \{{/radio-button}}<br>
 
-    \{{#radio-button value="one" groupValue=number disabled=numbersDisabled}}<br>
+    \{{#radio-button value="one" groupValue=number disabled=numbersDisabled name="number" changed="numberChanged"}}<br>
       &nbsp;&nbsp;One<br>
     \{{/radio-button}}<br>
-    \{{#radio-button value="two" groupValue=number disabled=numbersDisabled}}<br>
+    \{{#radio-button value="two" groupValue=number disabled=numbersDisabled name="number" changed="numberChanged"}}<br>
       &nbsp;&nbsp;Two<br>
     \{{/radio-button}}<br>
-    \{{#radio-button value="three" groupValue=number disabled=numbersDisabled}}<br>
+    \{{#radio-button value="three" groupValue=number disabled=numbersDisabled name="number" changed="numberChanged"}}<br>
       &nbsp;&nbsp;Three<br>
     \{{/radio-button}}<br>
   </code>
@@ -22,21 +22,21 @@
 <strong>Numbers Disabled:</strong> {{numbersDisabled}}
 <strong>Number:</strong> {{number}}
 <p>
-  {{#radio-button value=true groupValue=numbersDisabled}}
+  {{#radio-button value=true groupValue=numbersDisabled name="number-disabled" changed="numbersDisabledChanged"}}
     Disabled
   {{/radio-button}}
-  {{#radio-button value=false groupValue=numbersDisabled}}
+  {{#radio-button value=false groupValue=numbersDisabled name="number-disabled" changed="numbersDisabledChanged"}}
     Enabled
   {{/radio-button}}
 </p>
 <p>
-  {{#radio-button value="one" groupValue=number disabled=numbersDisabled}}
+  {{#radio-button value="one" groupValue=number disabled=numbersDisabled name="number" changed="numberChanged"}}
     One
   {{/radio-button}}
-  {{#radio-button value="two" groupValue=number disabled=numbersDisabled}}
+  {{#radio-button value="two" groupValue=number disabled=numbersDisabled name="number" changed="numberChanged"}}
     Two
   {{/radio-button}}
-  {{#radio-button value="three" groupValue=number disabled=numbersDisabled}}
+  {{#radio-button value="three" groupValue=number disabled=numbersDisabled name="number" changed="numberChanged"}}
     Three
   {{/radio-button}}
 </p>

--- a/tests/dummy/app/templates/examples/group-value-properties.hbs
+++ b/tests/dummy/app/templates/examples/group-value-properties.hbs
@@ -2,13 +2,13 @@
 
 <p style="background-color: #F7F7F7;padding: 15px 20px;">
   <code>
-    \{{#radio-button value="one" groupValue=reservation.number}}<br>
+    \{{#radio-button value="one" groupValue=reservation.number name="model-number" changed="modelNumberChanged"}}<br>
       &nbsp;&nbsp;One<br>
     \{{/radio-button}}<br>
-    \{{#radio-button value="two" groupValue=reservation.number}}<br>
+    \{{#radio-button value="two" groupValue=reservation.number name="model-number" changed="modelNumberChanged"}}<br>
       &nbsp;&nbsp;Two<br>
     \{{/radio-button}}<br>
-    \{{#radio-button value="three" groupValue=reservation.number}}<br>
+    \{{#radio-button value="three" groupValue=reservation.number name="model-number" changed="modelNumberChanged"}}<br>
       &nbsp;&nbsp;Three<br>
     \{{/radio-button}}<br>
   </code>
@@ -17,13 +17,13 @@
   Model.number: {{reservation.number}}
 </div>
 <div>
-  {{#radio-button value="one" groupValue=reservation.number}}
+  {{#radio-button value="one" groupValue=reservation.number name="model-number" changed="modelNumberChanged"}}
     One
   {{/radio-button}}
-  {{#radio-button value="two" groupValue=reservation.number}}
+  {{#radio-button value="two" groupValue=reservation.number name="model-number" changed="modelNumberChanged"}}
     Two
   {{/radio-button}}
-  {{#radio-button value="three" groupValue=reservation.number}}
+  {{#radio-button value="three" groupValue=reservation.number name="model-number" changed="modelNumberChanged"}}
     Three
   {{/radio-button}}
 </div>

--- a/tests/dummy/app/templates/examples/required.hbs
+++ b/tests/dummy/app/templates/examples/required.hbs
@@ -1,10 +1,10 @@
 <h3>Required</h3>
 <p style="background-color: #F7F7F7;padding: 15px 20px;">
   <code>
-    \{{#radio-button value=true groupValue=noDefault name="no-default" required=true}}<br>
+    \{{#radio-button value=true groupValue=noDefault required=true name="no-default" changed="noDefaultChanged"}}<br>
       &nbsp;&nbsp;Disabled<br>
     \{{/radio-button}}<br>
-    \{{#radio-button value=false groupValue=noDefault name="no-default"}}<br>
+    \{{#radio-button value=false groupValue=noDefault name="no-default" changed="noDefaultChanged"}}<br>
       &nbsp;&nbsp;Enabled<br>
     \{{/radio-button}}
   </code>
@@ -12,10 +12,10 @@
 <strong>No Default:</strong> {{noDefault}}
 <p>
   <form>
-    {{#radio-button value=false groupValue=noDefault name="no-default" required=true}}
+    {{#radio-button value=false groupValue=noDefault required=true name="no-default" changed="noDefaultChanged"}}
       Disabled
     {{/radio-button}}
-    {{#radio-button value=true groupValue=noDefault name="no-default"}}
+    {{#radio-button value=true groupValue=noDefault name="no-default" changed="noDefaultChanged"}}
       Enabled
     {{/radio-button}}<br>
     <button type="submit">Submit</button>

--- a/tests/unit/components/radio-button-test.js
+++ b/tests/unit/components/radio-button-test.js
@@ -24,7 +24,7 @@ test('begins checked when groupValue matches value', function(assert) {
   assert.equal(this.$('input').prop('checked'), true);
 });
 
-test('it updates when clicked, and triggers the `changed` action', function(assert) {
+test('it triggers the `changed` action when clicked', function(assert) {
   assert.expect(5);
 
   let changedActionCallCount = 0;
@@ -50,12 +50,12 @@ test('it updates when clicked, and triggers the `changed` action', function(asse
   });
 
   assert.equal(this.$('input').prop('checked'), true, 'updates element property');
-  assert.equal(this.get('groupValue'), 'component-value', 'updates groupValue');
+  assert.equal(this.get('groupValue'), 'initial-group-value', 'does not update groupValue');
 
   assert.equal(changedActionCallCount, 1);
 });
 
-test('it updates when the browser change event is fired', function(assert) {
+test('it triggers the `changed` action when the browser change event is fired', function(assert) {
   let changedActionCallCount = 0;
   this.on('changed', () => {
     changedActionCallCount++;
@@ -79,7 +79,7 @@ test('it updates when the browser change event is fired', function(assert) {
   });
 
   assert.equal(this.$('input').prop('checked'), true, 'updates DOM property');
-  assert.equal(this.get('groupValue'), 'component-value', 'updates groupValue');
+  assert.equal(this.get('groupValue'), 'initial-group-value', 'does not update groupValue');
   assert.equal(changedActionCallCount, 1);
 });
 


### PR DESCRIPTION
This removes the line that sets `groupValue` when a radio is clicked, in favor of only sending the `changed` action with the value of the now-checked radio button.

I have some concerns about this.  If the handler of the changed action does nothing, the newly clicked radio will still show as chosen, even though the `groupValue` will not equal the `value` for that radio button.

Further, if you don't set the `name` property on every instance of the component, you could end up with the user seeing multiple checked radio buttons for the same group.

Thoughts on how to proceed are welcome.
