### PR TITLE
Add default blueprint

### DIFF
--- a/blueprints/ember-radio-button/index.js
+++ b/blueprints/ember-radio-button/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  normalizeEntityName: function() {}
+};

--- a/blueprints/ember-radio-button/index.js
+++ b/blueprints/ember-radio-button/index.js
@@ -1,5 +1,7 @@
-'use strict';
+/*jshint node:true*/
 
 module.exports = {
+  description: 'install ember-radio-button into a project',
+
   normalizeEntityName: function() {}
 };


### PR DESCRIPTION
While doing some development on a local fork of `ember-radio-button`, I found the need to `npm link` it into a consuming application. The only way to have the addon's installation process triggered when doing this is for `ember g <addon-name>` to be run within the consuming project, so I generated a default blueprint for enabling that. 

I figured I'd contribute it back while I was at it -- for anyone else with the same use case 😄 . 