### PR TITLE
Add optional hasInnerSpan property to facilitate styling

### DIFF
--- a/app/templates/components/radio-button.hbs
+++ b/app/templates/components/radio-button.hbs
@@ -1,5 +1,5 @@
 {{#if hasBlock}}
-  <label class="ember-radio-button {{if checked 'checked'}} {{joinedClassNames}}" for={{radioId}}>
+  <label class="ember-radio-button {{if hasInnerSpan 'has-inner-span'}} {{if checked 'checked'}} {{joinedClassNames}}" for={{radioId}}>
     {{radio-button-input
         class=radioClass
         id=radioId
@@ -10,7 +10,13 @@
         value=value
         changed="changed"}}
 
-    {{yield}}
+    {{#if hasInnerSpan}}
+      <span class="inner-span">
+        {{yield}}
+      </span>
+    {{else}}
+      {{yield}}
+    {{/if}}
   </label>
 {{else}}
   {{radio-button-input

--- a/tests/dummy/app/templates/examples/has-inner-span.hbs
+++ b/tests/dummy/app/templates/examples/has-inner-span.hbs
@@ -1,0 +1,57 @@
+<style media="screen">
+  .has-inner-span .inner-span {
+    position: relative;
+    padding-left: 20px;
+  }
+  .has-inner-span .inner-span:after {
+    content:'';
+    width:15px;
+    height:15px;
+    border:1px solid;
+    position:absolute;
+    left:0;
+    top:1px;
+    border-radius:50% 0;
+    box-sizing:border-box;
+  }
+  .has-inner-span input[type="radio"] {
+    display: none;
+  }
+  .has-inner-span input[type="radio"]:checked + .inner-span {
+    color:blue;
+  }
+  .has-inner-span input[type="radio"]:checked + .inner-span:before {
+    content:'';
+    width:15px;
+    height:15px;
+    border:3px solid yellow;
+    position:absolute;
+    background-color: red;
+    left:0;
+    top:1px;
+    border-radius:50% 0;
+    box-sizing:border-box;
+  }
+</style>
+
+<h3>Advanced styling with hasInnerSpan</h3>
+
+<p style="background-color: #F7F7F7;padding: 15px 20px;">
+  <code>
+    \{{#radio-button value="Standard behavior if `hasInnerSpan` is null." groupValue=styled}}<br>
+      &nbsp;&nbsp;Standard<br>
+    \{{/radio-button}}<br>
+    \{{#radio-button value="If `hasInnerSpan` is true, label text is wrapped in `span.inner-span` element for easier styling." groupValue=styled hasInnerSpan=true}}<br>
+      &nbsp;&nbsp;hasInnerSpan<br>
+    \{{/radio-button}}<br>
+  </code>
+</p>
+<strong>Behavior:</strong> {{styled}}
+<p>
+  {{#radio-button value="Standard behavior if `hasInnerSpan` is null." groupValue=styled}}
+    Standard
+  {{/radio-button}}
+  {{#radio-button value="If `hasInnerSpan` is true, label text is wrapped in `span.inner-span` element for easier styling." groupValue=styled hasInnerSpan=true}}
+    hasInnerSpan
+  {{/radio-button}}
+</p>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -7,3 +7,5 @@
 {{partial "examples/group-value-properties" }}
 
 {{partial "examples/radio-id" }}
+
+{{partial "examples/has-inner-span" }}

--- a/tests/unit/components/radio-button-test.js
+++ b/tests/unit/components/radio-button-test.js
@@ -274,3 +274,20 @@ test('it checks the input when the label is clicked and has a `for` attribute', 
   assert.equal(this.$('input').hasClass('my-radio-class'), true, 'the input has the right class');
   assert.equal(this.$('input:checked').length, 1, 'clicking the label checks the radio');
 });
+
+test('it applies `has-inner-span` and `inner-span` classes when `hasInnerSpan` is true', function(assert) {
+  assert.expect(2);
+
+  this.render(hbs`
+    {{#radio-button
+        groupValue='chosen-value'
+        value='chosen-value'
+        hasInnerSpan=true
+    }}
+    Label
+    {{/radio-button}}
+  `);
+
+  assert.equal(this.$('label').hasClass('has-inner-span'), true, 'the label has been given the `has-inner-span` class');
+  assert.equal(this.$('span').hasClass('inner-span'), true, 'the span has been inserted with `inner-span` class');
+});


### PR DESCRIPTION
Hi! Long time listener, first time caller. I was wanting to do some custom radio button styling & noticed that there isn't currently a way to wrap the inner label text in a `span` or other DOM element. Rendered block buttons look like:

`<label class="ember-radio-button ember-view">`
`<input id="ember330" type="radio" value="green" class="ember-view">`
`Green`
`</label>`

I (and others) lean on this pretty heavily for the associated adjacent sibling selector and `:before` & `:after` pseudoclasses, so I added a `hasInnerSpan` property that can be optionally passed like this:

`{{#radio-button`
`value="green"`
`groupValue=color`
`hasInnerSpan=true}}`
`Green`
`{{/radio-button}}`

If you leave it out, everything behaves as normal, so existing implementations won't be affected. However, if you set it to true you get the following output:

`<label class="ember-radio-button ember-view has-inner-span">`
`<input id="ember330" type="radio" value="green" class="ember-view">`
`<span class="inner-span">Green</span>`
`</label>`

Allowing all kinds of CSS mischief with the button itself: 
![dummy 2016-10-26 18-08-28](https://cloud.githubusercontent.com/assets/3239830/19750595/3a8504a2-9ba7-11e6-97b5-6734074c9fe2.png)

My solution works on all modern browsers, though I'm happy to refactor if anyone has a better idea for how to do this!
