### PR TITLE
yield checked property to use it in the parent component

### DIFF
--- a/addon/templates/components/radio-button.hbs
+++ b/addon/templates/components/radio-button.hbs
@@ -10,7 +10,7 @@
         value=value
         changed="changed"}}
 
-    {{yield checked}}
+    {{yield (hash checked=checked)}}
   </label>
 {{else}}
   {{radio-button-input

--- a/addon/templates/components/radio-button.hbs
+++ b/addon/templates/components/radio-button.hbs
@@ -10,7 +10,7 @@
         value=value
         changed="changed"}}
 
-    {{yield}}
+    {{yield checked}}
   </label>
 {{else}}
   {{radio-button-input


### PR DESCRIPTION
Can be useful to yield the checked property to use it in the parent component of the radio button, for example to conditionally render some new inputs (e.g in a filter view):

````
    {{#radio-button
      value="contains"
      groupValue=filter.operator
      name="operator" as |radioChecked|
    }}
      {{#if radioChecked}}
        {{input type="text" value=filter.optionValue}}
      {{/if}}
    {{/radio-button}}
````