### PR TITLE
add support for aria-labelledby

### DIFF
--- a/addon/components/radio-button-input.js
+++ b/addon/components/radio-button-input.js
@@ -17,6 +17,7 @@ export default Component.extend({
   // radioClass - string
   // radioId - string
   // tabindex - number
+  // ariaLabelledby - string
 
   defaultLayout: null, // ie8 support
 
@@ -28,7 +29,8 @@ export default Component.extend({
     'required',
     'tabindex',
     'type',
-    'value'
+    'value',
+    'ariaLabelledby:aria-labelledby'
   ],
 
   checked: computed('groupValue', 'value', function() {

--- a/addon/components/radio-button.js
+++ b/addon/components/radio-button.js
@@ -17,6 +17,7 @@ export default Component.extend({
   // name - string
   // radioClass - string
   // radioId - string
+  // ariaLabelledby - string
 
   // polyfill hasBlock for ember versions < 1.13
   hasBlock: bool('template').readOnly(),

--- a/addon/templates/components/radio-button.hbs
+++ b/addon/templates/components/radio-button.hbs
@@ -10,6 +10,7 @@
         tabindex=tabindex
         groupValue=groupValue
         value=value
+        ariaLabelledby=ariaLabelledby
         changed="changed"}}
 
     {{yield}}
@@ -25,5 +26,6 @@
       tabindex=tabindex
       groupValue=groupValue
       value=value
+      ariaLabelledby=ariaLabelledby
       changed="changed"}}
 {{/if}}

--- a/tests/unit/components/radio-button-test.js
+++ b/tests/unit/components/radio-button-test.js
@@ -298,3 +298,21 @@ test('it updates when setting `value` with isEqual', function(assert) {
 
   assert.equal(this.$('input').prop('checked'), false);
 });
+
+test('it binds `aria-labelledby` when specified', function(assert) {
+  assert.expect(1);
+
+  this.set('ariaLabelledby', 'green-label');
+
+  this.render(hbs`
+    {{#radio-button
+      ariaLabelledby=ariaLabelledby
+      groupValue='initial-group-value'
+      value='value'
+    }}
+      Green
+    {{/radio-button}}
+  `);
+
+  assert.equal(this.$('input').attr('aria-labelledby'), 'green-label');
+});


### PR DESCRIPTION
This adds support for setting the `aria-labelledby` attribute on `radio-button-input` and having it set properly on the underlying `<input>`.