### PR TITLE
adds support for aria-describedby

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ If you want more control over the DOM, the non-block form only emits a single in
 | required   | boolean   | applies the `required` property to the input element  |
 | tabindex   | number    | applies a `tabindex` property to the input element    |
 | ariaLabelledby | string | applies an `aria-labelledby` attribute to the input element |
+| ariaDescribedby | string | applies an `aria-describedby` attribute to the input element |
 
 *Actions:*
 

--- a/addon/components/radio-button-input.js
+++ b/addon/components/radio-button-input.js
@@ -18,6 +18,7 @@ export default Component.extend({
   // radioId - string
   // tabindex - number
   // ariaLabelledby - string
+  // ariaDescribedby - string
 
   defaultLayout: null, // ie8 support
 
@@ -30,7 +31,8 @@ export default Component.extend({
     'tabindex',
     'type',
     'value',
-    'ariaLabelledby:aria-labelledby'
+    'ariaLabelledby:aria-labelledby',
+    'ariaDescribedby:aria-describedby'
   ],
 
   checked: computed('groupValue', 'value', function() {

--- a/addon/components/radio-button.js
+++ b/addon/components/radio-button.js
@@ -18,6 +18,7 @@ export default Component.extend({
   // radioClass - string
   // radioId - string
   // ariaLabelledby - string
+  // ariaDescribedby - string
 
   // polyfill hasBlock for ember versions < 1.13
   hasBlock: bool('template').readOnly(),

--- a/addon/templates/components/radio-button.hbs
+++ b/addon/templates/components/radio-button.hbs
@@ -11,6 +11,7 @@
         groupValue=groupValue
         value=value
         ariaLabelledby=ariaLabelledby
+        ariaDescribedby=ariaDescribedby
         changed="changed"}}
 
     {{yield}}
@@ -27,5 +28,6 @@
       groupValue=groupValue
       value=value
       ariaLabelledby=ariaLabelledby
+      ariaDescribedby=ariaDescribedby
       changed="changed"}}
 {{/if}}

--- a/tests/dummy/app/components/aria-example/template.hbs
+++ b/tests/dummy/app/components/aria-example/template.hbs
@@ -5,3 +5,9 @@
 
 <label id='label-blue'>Blue</label>
 {{radio-button name="aria-example" ariaLabelledby="label-blue" value="blue" groupValue=color}}
+
+<label id="label-purple">Purple</label>
+{{radio-button name="aria-example" ariaLabelledby="label-purple" ariaDescribedby="info" value="purple" groupValue=color}}
+<p id="info">
+  This color is created by combining Blue and Red.
+</p>

--- a/tests/unit/components/radio-button-test.js
+++ b/tests/unit/components/radio-button-test.js
@@ -316,3 +316,21 @@ test('it binds `aria-labelledby` when specified', function(assert) {
 
   assert.equal(this.$('input').attr('aria-labelledby'), 'green-label');
 });
+
+test('it binds `aria-describedby` when specified', function(assert) {
+  assert.expect(1);
+
+  this.set('ariaDescribedby', 'green-label');
+
+  this.render(hbs`
+    {{#radio-button
+      ariaDescribedby=ariaDescribedby
+      groupValue='initial-group-value'
+      value='value'
+    }}
+      Green
+    {{/radio-button}}
+  `);
+
+  assert.equal(this.$('input').attr('aria-describedby'), 'green-label');
+});


### PR DESCRIPTION
This adds support for setting the `aria-describedby` attribute on `radio-button-input` and having it set properly on the underlying `<input>`. Includes readme updates, a test, and an example.