### PR TITLE
Allowed the checked className to be overridden

### DIFF
--- a/addon/components/labeled-radio-button.js
+++ b/addon/components/labeled-radio-button.js
@@ -8,10 +8,14 @@ export default Component.extend({
   tagName: 'label',
   layout,
   attributeBindings: ['for'],
-  classNameBindings: ['checked'],
+  classNameBindings: ['_checkedClass'],
   classNames: ['ember-radio-button'],
   defaultLayout: null, // ie8 support
 
+  checkedClass: 'checked',
+  _checkedClass: computed('checked', 'checkedClass', function() {
+    return this.get('checked') ? this.get('checkedClass') : '';
+  }),
   checked: computed('groupValue', 'value', function() {
     return isEqual(this.get('groupValue'), this.get('value'));
   }).readOnly(),

--- a/addon/components/radio-button.js
+++ b/addon/components/radio-button.js
@@ -34,6 +34,8 @@ export default Component.extend({
   // is this needed here or just on radio-button-input?
   defaultLayout: null, // ie8 support
 
+  checkedClass: 'checked',
+
   checked: computed('groupValue', 'value', function() {
     return isEqual(this.get('groupValue'), this.get('value'));
   }).readOnly(),

--- a/addon/templates/components/radio-button.hbs
+++ b/addon/templates/components/radio-button.hbs
@@ -1,5 +1,5 @@
 {{#if hasBlock}}
-  <label class="ember-radio-button {{if checked 'checked'}} {{joinedClassNames}}" for={{radioId}}>
+  <label class="ember-radio-button {{if checked checkedClass}} {{joinedClassNames}}" for={{radioId}}>
     {{radio-button-input
         class=radioClass
         id=radioId

--- a/tests/dummy/app/components/user-checked-class-example/component.js
+++ b/tests/dummy/app/components/user-checked-class-example/component.js
@@ -1,0 +1,10 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+  color: 'green',
+  actions: {
+    colorChanged(color) {
+      window.alert(`Color changed to ${color}`);
+    }
+  }
+});

--- a/tests/dummy/app/components/user-checked-class-example/template.hbs
+++ b/tests/dummy/app/components/user-checked-class-example/template.hbs
@@ -1,0 +1,20 @@
+<h3>Using a different 'checked' class</h3>
+<p style="background-color: #F7F7F7;padding: 15px 20px;">
+    <code>
+      \{{#radio-button value="green" groupValue=color changed="colorChanged" checkedClass="my-custom-class"}}<br>
+        &nbsp;&nbsp;Green<br>
+      \{{/radio-button}}<br>
+      \{{#radio-button value="blue" groupValue=color changed="colorChanged" checkedClass="my-custom-class"}}<br>
+        &nbsp;&nbsp;Blue<br>
+      \{{/radio-button}}<br>
+    </code>
+</p>
+<strong>Selected Color:</strong> {{color}}
+<p>
+  {{#radio-button name="basic-example" value="green" groupValue=color changed="colorChanged" checkedClass="my-custom-class"}}
+      Green
+  {{/radio-button}}
+  {{#radio-button name="basic-example" value="blue" groupValue=color changed="colorChanged" checkedClass="my-custom-class"}}
+      Blue
+  {{/radio-button}}
+</p>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -13,3 +13,5 @@
 {{tab-index-example}}
 
 {{aria-example}}
+
+{{user-checked-class-example}}

--- a/tests/unit/components/labeled-radio-button-test.js
+++ b/tests/unit/components/labeled-radio-button-test.js
@@ -38,6 +38,28 @@ test('it gives the label of a wrapped checkbox a `checked` className', function(
   assert.equal(this.$('label').hasClass('checked'), true);
 });
 
+test('it gives the label of a wrapped checkbox a user supplied `checked` className', function(assert) {
+  assert.expect(2);
+
+  this.set('value', 'component-value');
+
+  this.render(hbs`
+    {{#labeled-radio-button
+      groupValue='initial-group-value'
+      value=value
+      checkedClass="my-custom-class"
+    }}
+      Blue
+    {{/labeled-radio-button}}
+  `);
+
+  assert.equal(this.$('label').hasClass('my-custom-class'), false);
+
+  this.set('value', 'initial-group-value');
+
+  assert.equal(this.$('label').hasClass('my-custom-class'), true);
+});
+
 test('it gives the label of a wrapped radio button a `for` attribute', function(assert) {
   assert.expect(4);
 

--- a/tests/unit/components/radio-button-test.js
+++ b/tests/unit/components/radio-button-test.js
@@ -109,6 +109,33 @@ test('it gives the label of a wrapped checkbox a `checked` className', function(
   assert.equal(this.$('label').hasClass('blue-radio'), true, 'has class `blue-radio`');
 });
 
+test('it gives the label of a wrapped checkbox the user supplied `checked` className', function(assert) {
+  assert.expect(4);
+
+  this.set('groupValue', 'initial-group-value');
+  this.set('value', 'component-value');
+
+  this.render(hbs`
+    {{#radio-button
+        groupValue=groupValue
+        value=value
+        checkedClass="my-custom-class"
+        changed='changed'
+        classNames='blue-radio'
+    ~}}
+      Blue
+    {{~/radio-button}}
+  `);
+
+  assert.equal(this.$('label').hasClass('my-custom-class'), false);
+
+  this.set('value', 'initial-group-value');
+
+  assert.equal(this.$('label').hasClass('my-custom-class'), true, 'has `checked` class');
+  assert.equal(this.$('label').hasClass('ember-radio-button'), true, 'has class `ember-radio-button`');
+  assert.equal(this.$('label').hasClass('blue-radio'), true, 'has class `blue-radio`');
+});
+
 test('it updates when setting `value`', function(assert) {
   assert.expect(3);
 


### PR DESCRIPTION
While converting an application, I found the y used a className of active instead of checked on the radio-button. I did not want to re-write the css, so this pull request allow the developer to change the className of the checked state.