### PR TITLE
Fix IE11 Value

### DIFF
--- a/addon/components/radio-button-input.js
+++ b/addon/components/radio-button-input.js
@@ -35,6 +35,11 @@ export default Component.extend({
     'ariaDescribedby:aria-describedby'
   ],
 
+  didRender() {
+    // Required for IE11 to correctly report its value
+    this.$().val(this.get('value'));
+  },
+
   checked: computed('groupValue', 'value', function() {
     return isEqual(this.get('groupValue'), this.get('value'));
   }).readOnly(),

--- a/tests/integration/components/radio-button-input-test.js
+++ b/tests/integration/components/radio-button-input-test.js
@@ -1,0 +1,21 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('radio-button-input', 'Integration | Component | radio button input', {
+  integration: true
+});
+
+// NOTE Be sure that this test passes in IE11!
+test('reports its value on the change event', function(assert) {
+  let expectedVal = 'blue';
+
+  this.set('changed', function(val) {
+    assert.equal(val, expectedVal);
+  });
+
+  this.set('value', expectedVal);
+
+  this.render(hbs`{{radio-button-input value=value changed=(action changed)}}`);
+
+  this.$('input').change();
+});


### PR DESCRIPTION
IE11 misreports the value of the input. The root problem is described at
the following URL:

https://github.com/emberjs/ember.js/issues/14712

Resolves #52