### PR TITLE
Use closure actions

### DIFF
--- a/addon/components/labeled-radio-button.js
+++ b/addon/components/labeled-radio-button.js
@@ -24,7 +24,11 @@ export default Component.extend({
 
   actions: {
     innerRadioChanged(value) {
-      this.sendAction('changed', value);
+      let changedAction = this.get('changed');
+      if (!changedAction && (typeof changedAction !== 'function')) {
+        return;
+      }
+      changedAction(value);
     }
   }
 });

--- a/addon/components/radio-button-input.js
+++ b/addon/components/radio-button-input.js
@@ -41,7 +41,11 @@ export default Component.extend({
   }).readOnly(),
 
   sendChangedAction() {
-    this.sendAction('changed', this.get('value'));
+    let changedAction = this.get('changed');
+    if (!changedAction && (typeof changedAction !== 'function')) {
+      return;
+    }
+    changedAction(this.get('value'));
   },
 
   change() {

--- a/addon/components/radio-button.js
+++ b/addon/components/radio-button.js
@@ -42,7 +42,11 @@ export default Component.extend({
 
   actions: {
     changed(newValue) {
-      this.sendAction('changed', newValue);
+      let changedAction = this.get('changed');
+      if (!changedAction && (typeof changedAction !== 'function')) {
+        return;
+      }
+      changedAction(newValue);
     }
   }
 });

--- a/addon/templates/components/labeled-radio-button.hbs
+++ b/addon/templates/components/labeled-radio-button.hbs
@@ -1,7 +1,7 @@
 {{radio-button
     radioClass=radioClass
     radioId=radioId
-    changed="innerRadioChanged"
+    changed=(action "innerRadioChanged")
     disabled=disabled
     groupValue=groupValue
     name=name

--- a/addon/templates/components/radio-button.hbs
+++ b/addon/templates/components/radio-button.hbs
@@ -12,7 +12,7 @@
         value=value
         ariaLabelledby=ariaLabelledby
         ariaDescribedby=ariaDescribedby
-        changed="changed"}}
+        changed=(action "changed")}}
 
     {{yield}}
   </label>
@@ -29,5 +29,5 @@
       value=value
       ariaLabelledby=ariaLabelledby
       ariaDescribedby=ariaDescribedby
-      changed="changed"}}
+      changed=(action "changed")}}
 {{/if}}

--- a/tests/unit/components/radio-button-test.js
+++ b/tests/unit/components/radio-button-test.js
@@ -28,7 +28,7 @@ test('it updates when clicked, and triggers the `changed` action', function(asse
   assert.expect(5);
 
   let changedActionCallCount = 0;
-  this.on('changed', function() {
+  this.set('changed', () => {
     changedActionCallCount++;
   });
 
@@ -38,7 +38,7 @@ test('it updates when clicked, and triggers the `changed` action', function(asse
     {{radio-button
         groupValue=groupValue
         value='component-value'
-        changed='changed'
+        changed=(action changed)
     }}
   `);
 
@@ -57,7 +57,7 @@ test('it updates when clicked, and triggers the `changed` action', function(asse
 
 test('it updates when the browser change event is fired', function(assert) {
   let changedActionCallCount = 0;
-  this.on('changed', () => {
+  this.set('changed', () => {
     changedActionCallCount++;
   });
 
@@ -67,7 +67,7 @@ test('it updates when the browser change event is fired', function(assert) {
     {{radio-button
         groupValue=groupValue
         value='component-value'
-        changed='changed'
+        changed=(action changed)
     }}
   `);
 
@@ -93,7 +93,6 @@ test('it gives the label of a wrapped checkbox a `checked` className', function(
     {{#radio-button
         groupValue=groupValue
         value=value
-        changed='changed'
         classNames='blue-radio'
     ~}}
       Blue
@@ -120,7 +119,6 @@ test('providing `checkedClass` gives the label a custom classname when the radio
         groupValue=groupValue
         value=value
         checkedClass="my-custom-class"
-        changed='changed'
         classNames='blue-radio'
     ~}}
       Blue


### PR DESCRIPTION
Fixes 
```
deprecate.js:102 DEPRECATION: You called <webapp@component:radio-button-input::ember965>.sendAction("changed") but Component#sendAction is deprecated. Please use closure actions instead. [deprecation id: ember-component.send-action] See https://emberjs.com/deprecations/v3.x#toc_ember-component-send-action for more details.
```