### PR TITLE
feat: allows extending the addon and overriding the radio-button component being used

### DIFF
--- a/addon/components/labeled-radio-button.js
+++ b/addon/components/labeled-radio-button.js
@@ -7,6 +7,13 @@ import layout from '../templates/components/labeled-radio-button';
 export default Component.extend({
   tagName: 'label',
   layout,
+
+  /**
+   * @property radioButtonComponent
+   * @type {String}
+   */
+  radioButtonComponent: 'radio-button',
+
   attributeBindings: ['for'],
   classNameBindings: ['_checkedClass'],
   classNames: ['ember-radio-button'],

--- a/addon/components/radio-button.js
+++ b/addon/components/radio-button.js
@@ -8,6 +8,12 @@ export default Component.extend({
   tagName: '',
   layout,
 
+  /**
+   * @property inputComponent
+   * @type {String}
+   */
+  inputComponent: 'radio-button-input',
+
   // value - passed in, required, the value for this radio button
   // groupValue - passed in, required, the currently selected value
 

--- a/addon/templates/components/labeled-radio-button.hbs
+++ b/addon/templates/components/labeled-radio-button.hbs
@@ -1,4 +1,4 @@
-{{radio-button
+{{component radioButtonComponent
     radioClass=radioClass
     radioId=radioId
     changed="innerRadioChanged"

--- a/addon/templates/components/radio-button.hbs
+++ b/addon/templates/components/radio-button.hbs
@@ -1,6 +1,6 @@
 {{#if hasBlock}}
   <label class="ember-radio-button {{if checked checkedClass}} {{joinedClassNames}}" for={{radioId}}>
-    {{radio-button-input
+    {{component inputComponent
         class=radioClass
         id=radioId
         autofocus=autofocus
@@ -17,7 +17,7 @@
     {{yield}}
   </label>
 {{else}}
-  {{radio-button-input
+  {{component inputComponent
       class=radioClass
       id=radioId
       autofocus=autofocus


### PR DESCRIPTION
In a project where this add-on is being extended, it is sometimes necessary to override the components which will be rendered, for example if the Haddon-user has extended `ember-radio-button` locally in their project.

This PR allows for overriding the components used.