### PR TITLE
Updates to call closure action

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A `radio-button` will be in a checked state when the `value` property matches th
 
 Clicking on a `radio-button` will set `groupValue` to its `value`.
 
-## Usage
+## Usage (Ember CLI < 1.13)
 
 ### Block Form
 
@@ -41,6 +41,45 @@ If you want more control over the DOM, the non-block form only emits a single in
     groupValue=color
     name="colors"
     changed="colorChanged"}}
+
+/* results in */
+<input id="ember345" class="ember-view" type="radio" value="green">
+```
+
+## Usage (Ember CLI 1.13 - Current)
+
+### Block Form
+
+The block form emits a label wrapping the input element and any elements passed to the block.
+
+**Template:**
+```javascript
+{{#radio-button
+    value="blue"
+    groupValue=color
+    changed=(action "colorChanged")
+}}
+    <span>Blue</span>
+{{/radio-button}}
+
+/* results in */
+<label id="ember346" class="ember-view ember-radio-button">
+  <input id="ember347" class="ember-view" type="radio" value="blue">
+  <span>Blue</span>
+</label>
+```
+
+### Non-block form
+
+If you want more control over the DOM, the non-block form only emits a single input element
+
+```javascript
+{{radio-button
+    value="green"
+    groupValue=color
+    name="colors"
+    changed=(action "colorChanged")
+}}
 
 /* results in */
 <input id="ember345" class="ember-view" type="radio" value="green">

--- a/addon/components/labeled-radio-button.js
+++ b/addon/components/labeled-radio-button.js
@@ -24,6 +24,10 @@ export default Component.extend({
 
   actions: {
     innerRadioChanged(value) {
+      if (typeof this.get('changed') === 'function') {
+        return this.get('changed')(value);
+      }
+
       this.sendAction('changed', value);
     }
   }

--- a/addon/components/radio-button-input.js
+++ b/addon/components/radio-button-input.js
@@ -40,7 +40,9 @@ export default Component.extend({
     return isEqual(this.get('groupValue'), this.get('value'));
   }).readOnly(),
 
-  sendChangedAction(value) {
+  sendChangedAction() {
+    let value = this.get('value');
+
     if (typeof this.get('changed') === 'function') {
       return this.get('changed')(value);
     }
@@ -54,7 +56,7 @@ export default Component.extend({
 
     if (groupValue !== value) {
       this.set('groupValue', value); // violates DDAU
-      run.once(this, 'sendChangedAction', value);
+      run.once(this, 'sendChangedAction');
     }
   }
 });

--- a/addon/components/radio-button-input.js
+++ b/addon/components/radio-button-input.js
@@ -40,8 +40,12 @@ export default Component.extend({
     return isEqual(this.get('groupValue'), this.get('value'));
   }).readOnly(),
 
-  sendChangedAction() {
-    this.sendAction('changed', this.get('value'));
+  sendChangedAction(value) {
+    if (typeof this.get('changed') === 'function') {
+      return this.get('changed')(value);
+    }
+
+    this.sendAction('changed', value);
   },
 
   change() {
@@ -50,7 +54,7 @@ export default Component.extend({
 
     if (groupValue !== value) {
       this.set('groupValue', value); // violates DDAU
-      run.once(this, 'sendChangedAction');
+      run.once(this, 'sendChangedAction', value);
     }
   }
 });

--- a/addon/components/radio-button.js
+++ b/addon/components/radio-button.js
@@ -42,6 +42,10 @@ export default Component.extend({
 
   actions: {
     changed(newValue) {
+      if (typeof this.get('changed') === 'function') {
+        return this.get('changed')(newValue);
+      }
+
       this.sendAction('changed', newValue);
     }
   }

--- a/tests/unit/components/radio-button-test.js
+++ b/tests/unit/components/radio-button-test.js
@@ -6,6 +6,7 @@ import {
 } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { alice, alice2, bob } from '../../helpers/person';
+import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 
 moduleForComponent('radio-button', 'RadioButtonComponent', {
   integration: true
@@ -362,3 +363,36 @@ test('it binds `aria-describedby` when specified', function(assert) {
 
   assert.equal(this.$('input').attr('aria-describedby'), 'green-label');
 });
+
+if (hasEmberVersion(1, 13)) {
+  test('it updates when clicked, and triggers the `changed` action when a closure action is passed in', function(assert) {
+    assert.expect(5);
+
+    let changedActionCallCount = 0;
+    this.on('changed', function() {
+      changedActionCallCount++;
+    });
+
+    this.set('groupValue', 'initial-group-value');
+
+    this.render(hbs`
+      {{radio-button
+          groupValue=groupValue
+          value='component-value'
+          changed=(action 'changed')
+      }}
+    `);
+
+    assert.equal(changedActionCallCount, 0);
+    assert.equal(this.$('input').prop('checked'), false);
+
+    run(() => {
+      this.$('input').trigger('click');
+    });
+
+    assert.equal(this.$('input').prop('checked'), true, 'updates element property');
+    assert.equal(this.get('groupValue'), 'component-value', 'updates groupValue');
+
+    assert.equal(changedActionCallCount, 1);
+  });
+}


### PR DESCRIPTION
Allows for closure actions to be passed in to address `sendAction` deprecation in a non-breaking way