### PR TITLE
Closure actions readme and dummy app updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,45 +8,7 @@ A `radio-button` will be in a checked state when the `value` property matches th
 
 Clicking on a `radio-button` will set `groupValue` to its `value`.
 
-## Usage (Ember CLI < 1.13)
-
-### Block Form
-
-The block form emits a label wrapping the input element and any elements passed to the block.
-
-**Template:**
-```javascript
-{{#radio-button
-    value="blue"
-    groupValue=color
-    changed="colorChanged"
-}}
-    <span>Blue</span>
-{{/radio-button}}
-
-/* results in */
-<label id="ember346" class="ember-view ember-radio-button">
-  <input id="ember347" class="ember-view" type="radio" value="blue">
-  <span>Blue</span>
-</label>
-```
-
-### Non-block form
-
-If you want more control over the DOM, the non-block form only emits a single input element
-
-```javascript
-{{radio-button
-    value="green"
-    groupValue=color
-    name="colors"
-    changed="colorChanged"}}
-
-/* results in */
-<input id="ember345" class="ember-view" type="radio" value="green">
-```
-
-## Usage (Ember CLI 1.13 - Current)
+## Usage
 
 ### Block Form
 
@@ -126,6 +88,10 @@ If you want more control over the DOM, the non-block form only emits a single in
 ## Installing
 
 `ember install ember-radio-button`
+
+## Legacy Action Support
+
+A string can be supplied for the `changed` property to enable legacy `sendAction` style action propagation.
 
 ## Older versions of ember
 

--- a/tests/dummy/app/components/basic-example/template.hbs
+++ b/tests/dummy/app/components/basic-example/template.hbs
@@ -1,19 +1,20 @@
+<h3>Basic Usage</h3>
 <p style="background-color: #F7F7F7;padding: 15px 20px;">
   <code>
-    \{{#radio-button value="green" groupValue=color changed="colorChanged"}}<br>
+    \{{#radio-button value="green" groupValue=color changed=(action "colorChanged")}}<br>
       &nbsp;&nbsp;Green<br>
     \{{/radio-button}}<br>
-    \{{#radio-button value="blue" groupValue=color changed="colorChanged"}}<br>
+    \{{#radio-button value="blue" groupValue=color changed=(action "colorChanged")}}<br>
       &nbsp;&nbsp;Blue<br>
     \{{/radio-button}}<br>
   </code>
 </p>
 <strong>Selected Color:</strong> {{color}}
 <p>
-  {{#radio-button name="basic-example" value="green" groupValue=color changed="colorChanged"}}
+  {{#radio-button name="basic-example" value="green" groupValue=color changed=(action "colorChanged")}}
     Green
   {{/radio-button}}
-  {{#radio-button name="basic-example" value="blue" groupValue=color changed="colorChanged"}}
+  {{#radio-button name="basic-example" value="blue" groupValue=color changed=(action "colorChanged")}}
     Blue
   {{/radio-button}}
 </p>

--- a/tests/dummy/app/components/id-and-class-example/template.hbs
+++ b/tests/dummy/app/components/id-and-class-example/template.hbs
@@ -2,20 +2,20 @@
 
 <p style="background-color: #F7F7F7;padding: 15px 20px;">
   <code>
-    \{{#radio-button value="purple" radioId="purple-radio" radioClass="my-custom-radio-class" groupValue=color changed="colorChanged"}}<br>
+    \{{#radio-button value="purple" radioId="purple-radio" radioClass="my-custom-radio-class" groupValue=color changed=(action "colorChanged")}}<br>
       &nbsp;&nbsp;Purple<br>
     \{{/radio-button}}<br>
-    \{{#radio-button value="orange" radioClass="my-custom-radio-class" radioId="orange-radio" groupValue=color changed="colorChanged"}}<br>
+    \{{#radio-button value="orange" radioClass="my-custom-radio-class" radioId="orange-radio" groupValue=color changed=(action "colorChanged")}}<br>
       &nbsp;&nbsp;Orange<br>
     \{{/radio-button}}<br>
   </code>
 </p>
 <strong>Selected Color:</strong> {{color}}
 <p>
-  {{#radio-button radioId="purple-radio" radioClass="my-custom-radio-class" value="purple" groupValue=color changed="colorChanged"}}
+  {{#radio-button name="id-and-class" radioId="purple-radio" radioClass="my-custom-radio-class" value="purple" groupValue=color changed=(action "colorChanged")}}
     Purple
   {{/radio-button}}
-  {{#radio-button radioId="orange-radio" radioClass="my-custom-radio-class" value="orange" groupValue=color changed="colorChanged"}}
+  {{#radio-button name="id-and-class" radioId="orange-radio" radioClass="my-custom-radio-class" value="orange" groupValue=color changed=(action "colorChanged")}}
     Orange
   {{/radio-button}}
 </p>

--- a/tests/dummy/app/components/legacy-actions-example/component.js
+++ b/tests/dummy/app/components/legacy-actions-example/component.js
@@ -1,0 +1,11 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+  color: 'maroon',
+  actions: {
+    legacyColorChanged(color) {
+      window.alert(`Color changed to ${color}`);
+    }
+  }
+});
+

--- a/tests/dummy/app/components/legacy-actions-example/template.hbs
+++ b/tests/dummy/app/components/legacy-actions-example/template.hbs
@@ -1,0 +1,20 @@
+<h3>Legacy Action Example</h3>
+<p style="background-color: #F7F7F7;padding: 15px 20px;">
+  <code>
+    \{{#radio-button value="maroon" groupValue=color changed="legacyColorChanged"}}<br>
+      &nbsp;&nbsp;Maroon<br>
+    \{{/radio-button}}<br>
+    \{{#radio-button value="blue" groupValue=color changed="legacyColorChanged"}}<br>
+      &nbsp;&nbsp;Blue<br>
+    \{{/radio-button}}<br>
+  </code>
+</p>
+<strong>Selected Color:</strong> {{color}}
+<p>
+  {{#radio-button name="legacy-action-example" value="maroon" groupValue=color changed="legacyColorChanged"}}
+    Maroon
+  {{/radio-button}}
+  {{#radio-button name="legacy-action-example" value="coral" groupValue=color changed="legacyColorChanged"}}
+    Coral
+  {{/radio-button}}
+</p>

--- a/tests/dummy/app/components/user-checked-class-example/template.hbs
+++ b/tests/dummy/app/components/user-checked-class-example/template.hbs
@@ -1,20 +1,20 @@
 <h3>Using a different 'checked' class</h3>
 <p style="background-color: #F7F7F7;padding: 15px 20px;">
     <code>
-      \{{#radio-button value="green" groupValue=color changed="colorChanged" checkedClass="my-custom-class"}}<br>
+      \{{#radio-button value="green" groupValue=color changed=(action "colorChanged") checkedClass="my-custom-class"}}<br>
         &nbsp;&nbsp;Green<br>
       \{{/radio-button}}<br>
-      \{{#radio-button value="blue" groupValue=color changed="colorChanged" checkedClass="my-custom-class"}}<br>
+      \{{#radio-button value="blue" groupValue=color changed=(action "colorChanged") checkedClass="my-custom-class"}}<br>
         &nbsp;&nbsp;Blue<br>
       \{{/radio-button}}<br>
     </code>
 </p>
 <strong>Selected Color:</strong> {{color}}
 <p>
-  {{#radio-button name="user-checked-class-example" value="green" groupValue=color changed="colorChanged" checkedClass="my-custom-class"}}
+  {{#radio-button name="user-checked-class-example" value="green" groupValue=color changed=(action "colorChanged") checkedClass="my-custom-class"}}
       Green
   {{/radio-button}}
-  {{#radio-button name="user-checked-class-example" value="blue" groupValue=color changed="colorChanged" checkedClass="my-custom-class"}}
+  {{#radio-button name="user-checked-class-example" value="blue" groupValue=color changed=(action "colorChanged") checkedClass="my-custom-class"}}
       Blue
   {{/radio-button}}
 </p>

--- a/tests/dummy/app/components/user-checked-class-example/template.hbs
+++ b/tests/dummy/app/components/user-checked-class-example/template.hbs
@@ -11,10 +11,10 @@
 </p>
 <strong>Selected Color:</strong> {{color}}
 <p>
-  {{#radio-button name="basic-example" value="green" groupValue=color changed="colorChanged" checkedClass="my-custom-class"}}
+  {{#radio-button name="user-checked-class-example" value="green" groupValue=color changed="colorChanged" checkedClass="my-custom-class"}}
       Green
   {{/radio-button}}
-  {{#radio-button name="basic-example" value="blue" groupValue=color changed="colorChanged" checkedClass="my-custom-class"}}
+  {{#radio-button name="user-checked-class-example" value="blue" groupValue=color changed="colorChanged" checkedClass="my-custom-class"}}
       Blue
   {{/radio-button}}
 </p>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -15,3 +15,5 @@
 {{aria-example}}
 
 {{user-checked-class-example}}
+
+{{legacy-actions-example}}


### PR DESCRIPTION
- Update README and Dummy app examples to primarily use closure actions
- Add a new legacy actions section to Dummy app examples

It's worth noting that `sendAction` is still used internally by the `radio-button` components, even when a closure action is provided by the end user. Since [sendAction was deprecated in Ember 3.4](https://deprecations.emberjs.com/v3.x/#toc_ember-component-send-action), users using ember-radio-button with ember 3.4 and later will see warnings.