### PR TITLE
Drop 1.x support, make 2.8 the oldest supported version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,16 +18,16 @@ env:
     # See https://git.io/vdao3 for details.
     - JOBS=1
   matrix:
-    - EMBER_TRY_SCENARIO=ember-1.11
-    - EMBER_TRY_SCENARIO=ember-1.12
-    - EMBER_TRY_SCENARIO=ember-1.13
-    - EMBER_TRY_SCENARIO=ember-lts-2.4
     - EMBER_TRY_SCENARIO=ember-lts-2.8
     - EMBER_TRY_SCENARIO=ember-lts-2.12
+    - EMBER_TRY_SCENARIO=ember-lts-2.16
+    - EMBER_TRY_SCENARIO=ember-lts-2.18
+    - EMBER_TRY_SCENARIO=ember-lts-3.4
     - EMBER_TRY_SCENARIO=ember-release
     - EMBER_TRY_SCENARIO=ember-beta
     - EMBER_TRY_SCENARIO=ember-canary
     - EMBER_TRY_SCENARIO=ember-default
+    - EMBER_TRY_SCENARIO=ember-default-with-jquery
 
 matrix:
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ If you want more control over the DOM, the non-block form only emits a single in
 
 [More example usage](https://github.com/yapplabs/ember-radio-button/tree/master/tests/dummy/app/components) can be seen in the test application.
 
+## Supported Ember Versions
+
+| ember-radio-button version | supports                 |
+|----------------------------|--------------------------|
+| 2.x                        | Ember 2.8+               |
+| 1.x                        | Ember 1.11+              |
 
 ## Properties
 

--- a/addon/components/radio-button.js
+++ b/addon/components/radio-button.js
@@ -1,4 +1,3 @@
-import { bool } from '@ember/object/computed';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { isEqual } from '@ember/utils';
@@ -19,9 +18,6 @@ export default Component.extend({
   // radioId - string
   // ariaLabelledby - string
   // ariaDescribedby - string
-
-  // polyfill hasBlock for ember versions < 1.13
-  hasBlock: bool('template').readOnly(),
 
   joinedClassNames: computed('classNames', function() {
     let classNames = this.get('classNames');

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -90,6 +90,38 @@ module.exports = {
       }
     },
     {
+      name: 'ember-lts-2.16',
+      env: {
+        EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
+      },
+      npm: {
+        devDependencies: {
+          '@ember/jquery': '^0.5.1',
+          'ember-source': '~2.16.0'
+        }
+      }
+    },
+    {
+      name: 'ember-lts-2.18',
+      env: {
+        EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
+      },
+      npm: {
+        devDependencies: {
+          '@ember/jquery': '^0.5.1',
+          'ember-source': '~2.18.0'
+        }
+      }
+    },
+    {
+      name: 'ember-lts-3.4',
+      npm: {
+        devDependencies: {
+          'ember-source': '~3.4.0'
+        }
+      }
+    },
+    {
       name: 'ember-release',
       bower: {
         dependencies: {
@@ -142,6 +174,17 @@ module.exports = {
       npm: {
         devDependencies: {}
       }
-    }
+    },
+    {
+      name: 'ember-default-with-jquery',
+      env: {
+        EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
+      },
+      npm: {
+        devDependencies: {
+          '@ember/jquery': '^0.5.1'
+        }
+      }
+    },
   ]
 };


### PR DESCRIPTION
per https://emberjs.com/ember-community-survey-2019/#MS_Q401 2.8 feels like a reasonable new choice for the oldest version to support. Over 7% of survey responders were working with a 2.8 build in both the 2018 and 2019 surveys.

Todo
 - [x] add an ember version compatibility table to the readme