### PR TITLE
set aria-checked attribute value to string

### DIFF
--- a/addon/components/radio-button-input.js
+++ b/addon/components/radio-button-input.js
@@ -33,12 +33,22 @@ export default Component.extend({
     'value',
     'ariaLabelledby:aria-labelledby',
     'ariaDescribedby:aria-describedby',
-    'checked:aria-checked'
+    'checkedStr:aria-checked'
   ],
 
   checked: computed('groupValue', 'value', function() {
     return isEqual(this.get('groupValue'), this.get('value'));
   }).readOnly(),
+
+  checkedStr: computed('checked', function() {
+    let checked = this.get('checked');
+
+    if (typeof checked === 'boolean') {
+      return checked.toString();
+    }
+
+    return null;
+  }),
 
   invokeChangedAction() {
     let value = this.get('value');

--- a/tests/unit/components/radio-button-test.js
+++ b/tests/unit/components/radio-button-test.js
@@ -384,7 +384,7 @@ test('it binds `aria-describedby` when specified', function(assert) {
 });
 
 test('it updates when clicked, and supports legacy-style string `changed` actions', function(assert) {
-  assert.expect(5);
+  assert.expect(7);
 
   let changedActionCallCount = 0;
   this.on('changed', function() {
@@ -403,12 +403,14 @@ test('it updates when clicked, and supports legacy-style string `changed` action
 
   assert.equal(changedActionCallCount, 0);
   assert.equal(this.$('input').prop('checked'), false);
+  assert.equal(this.$('input').attr('aria-checked'), 'false');
 
   run(() => {
     this.$('input').trigger('click');
   });
 
   assert.equal(this.$('input').prop('checked'), true, 'updates element property');
+  assert.equal(this.$('input').attr('aria-checked'), 'true', 'updates element property');
   assert.equal(this.get('groupValue'), 'component-value', 'updates groupValue');
 
   assert.equal(changedActionCallCount, 1);


### PR DESCRIPTION
`aria-checked` attribute should have a string value, eg. `aria-checked="true"`. Currently it is a standalone attribute when `checked` is true (due to the way `attributeBindings` works with booleans), which breaks A11y rules, see https://dequeuniversity.com/rules/axe/3.2/aria-valid-attr-value