### PR TITLE
Fix: set correct project version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-radio-button",
-  "version": "0.0.0",
+  "version": "3.0.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
# Current behavior:
- After using `ember install ember-radio-button` package will be installed in version `2.0.1`

# Expect behavior:
- After using `ember install ember-radio-button` will be installed in version `3.x` with support Ember > 3.16 under the hood

# Notice:
- Please add tag with version `v3.0.0`