### PR TITLE
fix aria-checked

### DIFF
--- a/addon/components/radio-button-input.hbs
+++ b/addon/components/radio-button-input.hbs
@@ -1,1 +1,1 @@
-<input ...attributes type="radio" aria-checked={{this.checkedStr}} value={{@value}} {{on "change" this.change}} />
+<input ...attributes type="radio" checked={{@checked}} aria-checked={{this.checkedStr}} value={{@value}} {{on "change" this.change}} />

--- a/addon/components/radio-button.hbs
+++ b/addon/components/radio-button.hbs
@@ -10,6 +10,7 @@
       tabindex={{@tabindex}}
       @groupValue={{@groupValue}}
       checked={{this.checked}}
+      @checked={{this.checked}}
       @value={{@value}}
       aria-labelledby={{@ariaLabelledby}}
       aria-describedby={{@ariaDescribedby}}
@@ -28,6 +29,7 @@
     tabindex={{@tabindex}}
     @groupValue={{@groupValue}}
     checked={{this.checked}}
+    @checked={{this.checked}}
     @value={{@value}}
     aria-labelledby={{@ariaLabelledby}}
     aria-describedby={{@ariaDescribedby}}

--- a/addon/components/radio-button.hbs
+++ b/addon/components/radio-button.hbs
@@ -9,7 +9,6 @@
       required={{@required}}
       tabindex={{@tabindex}}
       @groupValue={{@groupValue}}
-      checked={{this.checked}}
       @checked={{this.checked}}
       @value={{@value}}
       aria-labelledby={{@ariaLabelledby}}
@@ -28,7 +27,6 @@
     required={{@required}}
     tabindex={{@tabindex}}
     @groupValue={{@groupValue}}
-    checked={{this.checked}}
     @checked={{this.checked}}
     @value={{@value}}
     aria-labelledby={{@ariaLabelledby}}

--- a/tests/integration/components/radio-button-test.js
+++ b/tests/integration/components/radio-button-test.js
@@ -8,7 +8,7 @@ module('Integration | Components | Radio Button', function (hooks) {
   setupRenderingTest(hooks);
 
   test('begins checked when groupValue matches value', async function (assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     await render(hbs`
       <RadioButton
@@ -18,10 +18,11 @@ module('Integration | Components | Radio Button', function (hooks) {
     `);
 
     assert.dom('input').isChecked();
+    assert.dom('input').hasAttribute('aria-checked', 'true');
   });
 
   test('it updates when clicked, and triggers the `changed` action', async function (assert) {
-    assert.expect(5);
+    assert.expect(7);
 
     let changedActionCallCount = 0;
 
@@ -42,10 +43,14 @@ module('Integration | Components | Radio Button', function (hooks) {
 
     assert.strictEqual(changedActionCallCount, 0);
     assert.dom('input').isNotChecked();
+    assert.dom('input').doesNotHaveAttribute('aria-checked');
 
     await triggerEvent('input', 'click');
 
     assert.dom('input').isChecked('updates element property');
+    assert
+      .dom('input')
+      .hasAttribute('aria-checked', 'true', 'updates aria-checked property');
 
     assert.strictEqual(changedActionCallCount, 1);
   });

--- a/tests/integration/components/radio-button-test.js
+++ b/tests/integration/components/radio-button-test.js
@@ -28,9 +28,10 @@ module('Integration | Components | Radio Button', function (hooks) {
 
     this.set('groupValue', 'initial-group-value');
 
-    this.set('changed', function (newValue) {
+    this.set('changed', (newValue) => {
       changedActionCallCount++;
       assert.strictEqual(newValue, 'component-value', 'updates groupValue');
+      this.set('groupValue', newValue);
     });
 
     await render(hbs`
@@ -43,7 +44,13 @@ module('Integration | Components | Radio Button', function (hooks) {
 
     assert.strictEqual(changedActionCallCount, 0);
     assert.dom('input').isNotChecked();
-    assert.dom('input').doesNotHaveAttribute('aria-checked');
+    assert
+      .dom('input')
+      .hasAttribute(
+        'aria-checked',
+        'false',
+        'aria-checked property starts false'
+      );
 
     await triggerEvent('input', 'click');
 


### PR DESCRIPTION
Upon updating our app to the latest ember-radio-button, which we need to do to fix deprecations, we had test failures showing that our aria-checked values were not what we expected.

This is the same issue described in #114 and I used the first commit of #115 as a starting point for the fix.