### PR TITLE
updated cli-htmlbar version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-radio-button",
   "version": "3.0.0-beta.1",
-  "description": "This addon provides a RadioButton component",
+  "description": "This addon provides a RadioButton component...",
   "keywords": [
     "ember-addon"
   ],
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.26.11",
-    "ember-cli-htmlbars": "^5.7.1",
+    "ember-cli-htmlbars": "^6.0.1",
     "webpack": "^5.72.1"
   },
   "devDependencies": {
@@ -54,7 +54,7 @@
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.5",
     "ember-resolver": "^8.0.3",
-    "ember-source": "~3.28.0",
+    "ember-source": "~4.0.1",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^3.6.0",
     "ember-try": "^1.4.0",


### PR DESCRIPTION
updated cli-htmlbar version (6.0.1)..
(if we using old version of ember-cli-htmlbars in emberjs >=4.0.0, then it's throwing ember is not defined error...)